### PR TITLE
Make indirect usage of defmt through smoltcp optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ embedded-hal = "1.0"
 embedded-hal-async = "1.0"
 smoltcp = { version = ">=0.11", default-features = false, features = [
     "socket-raw",
-    "defmt",
     "medium-ieee802154",
 ] }
 nb = "1.0"
@@ -50,5 +49,5 @@ default-features = false
 default = ["async", "rssi"]
 std = ["serde/std", "num_enum/std"]
 async = []
-defmt = ["dep:defmt"]
+defmt = ["dep:defmt", "smoltcp/defmt"]
 rssi = ["dep:num-traits"]


### PR DESCRIPTION
Also open as a PR in the main repo here: https://github.com/ProfFan/dw3000-ng/pull/26